### PR TITLE
feat: allow use of private key when connecting to sftp

### DIFF
--- a/fileio/sftp-store_test.go
+++ b/fileio/sftp-store_test.go
@@ -9,7 +9,7 @@ import (
 
 func TestSFTPPrivateKey(t *testing.T) {
 	sftpStore := SFTPStore{
-		Address:        "localhost:22",
+		Address:        os.Getenv("SFTP_ADDRESS"),
 		User:           os.Getenv("SFTP_USER"),
 		PrivateKeyPath: os.Getenv("SFTP_PRIVATE_KEY_PATH"),
 	}

--- a/fileio/sftp-store_test.go
+++ b/fileio/sftp-store_test.go
@@ -1,0 +1,42 @@
+package fileio
+
+import (
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSFTPPrivateKey(t *testing.T) {
+	sftpStore := SFTPStore{
+		Address:        "localhost:22",
+		User:           os.Getenv("SFTP_USER"),
+		PrivateKeyPath: os.Getenv("SFTP_PRIVATE_KEY_PATH"),
+	}
+
+	err := sftpStore.connect()
+	assert.NoError(t, err)
+
+	files, err := sftpStore.List("/")
+	assert.NotEmpty(t, files)
+	assert.NoError(t, err)
+
+	sftpStore.disconnect()
+}
+
+func TestSFTPPassword(t *testing.T) {
+	sftpStore := SFTPStore{
+		Address:  "localhost:22",
+		User:     os.Getenv("SFTP_USER"),
+		Password: os.Getenv("SFTP_PASSWORD"),
+	}
+
+	err := sftpStore.connect()
+	assert.NoError(t, err)
+
+	files, err := sftpStore.List("/")
+	assert.NotEmpty(t, files)
+	assert.NoError(t, err)
+
+	sftpStore.disconnect()
+}


### PR DESCRIPTION
This pull request introduces changes to the `fileio` package to enhance the SFTP connection functionality by adding support for private key authentication and includes corresponding tests.

Enhancements to SFTP connection:

* [`fileio/sftp-store.go`](diffhunk://#diff-4c9937e6b0c78da04b134033eca00d7437f1ba044f0ce0da60ddf0727e8228c9R5-R45): Added support for private key authentication by introducing the `PrivateKeyPath` field and modifying the `connect` method to handle both private key and password authentication methods.

Testing the new functionality:

* [`fileio/sftp-store_test.go`](diffhunk://#diff-f570360c6aa8eb091085bdf4a9ac2ad542fab68494daf076e441e9abf70b75faR1-R42): Added tests to verify the SFTP connection using both private key and password authentication methods. The tests ensure that the connection is successful and that the file listing is not empty.