### PR TITLE
feat: truncate pd summary over 1024 chars

### DIFF
--- a/errlib/pagerduty.go
+++ b/errlib/pagerduty.go
@@ -33,6 +33,8 @@ type EventTraceback struct {
 	Traceback string
 }
 
+const maxSummaryLength int = 1024
+
 // PagerDuty implements methods to send notifications to pagerduty in the format:
 // [${Product}] ${Severity} event @ ${LogReference} - ${Timestamp}
 type PagerDuty struct {
@@ -110,6 +112,8 @@ func (p PagerDuty) createPagerdutyAlert(msg string, severity string) {
 	}
 
 	summary := fmt.Sprintf("[%s] %s", p.Product, msg)
+	summary = stdext.EllipticalTruncate(summary, maxSummaryLength)
+
 	details := EventTraceback{
 		Message:   msg,
 		Time:      time.Now().Format(time.RFC3339),


### PR DESCRIPTION
Fixes
```
Unable to create pagerduty event! <nil>
HTTP Status Code: 400, Message: {"errors":["'summary' is too long (maiximum is 1024 characters)"],"message":"Event object is invalid","status":"invalid event"}
```
This pull request includes changes to the `errlib/pagerduty.go` file to enhance the handling of alert summaries in PagerDuty notifications. The most important changes include defining a maximum summary length and truncating the summary to fit within this limit.

Enhancements to PagerDuty notifications:

* [`errlib/pagerduty.go`](diffhunk://#diff-908ebbb56152fad821cc774380a033c28bbea76b65246074cbf58c18420c98feR36-R37): Added a constant `maxSummaryLength` to define the maximum length for alert summaries.
* [`errlib/pagerduty.go`](diffhunk://#diff-908ebbb56152fad821cc774380a033c28bbea76b65246074cbf58c18420c98feR115-R116): Modified the `createPagerdutyAlert` function to truncate the summary using `stdext.EllipticalTruncate` to ensure it does not exceed the defined maximum length.