### PR TITLE
feat: fix s3 store trace msg

### DIFF
--- a/fileio/s3-store.go
+++ b/fileio/s3-store.go
@@ -38,7 +38,7 @@ func (s S3Store) Save(path string, content string) error {
 }
 
 func (s S3Store) Load(path string) (content string, err error) {
-	log.Trace(fmt.Sprintf("Downloading s3://%s%s", *s.Bucket, path))
+	log.Trace(fmt.Sprintf("Downloading s3://%s/%s", *s.Bucket, path))
 	output, err := s.s3.GetObject(&s3.GetObjectInput{
 		Bucket: s.Bucket,
 		Key:    &path,


### PR DESCRIPTION
This pull request includes a minor but important change to the `fileio/s3-store.go` file. The change corrects the format of the S3 URL in the log trace message to include a slash between the bucket name and the path.

* [`fileio/s3-store.go`](diffhunk://#diff-8fb10a853b681fe506d5cbba0286e78162e3b6fed34027ff3898d38c1d83ab61L41-R41): Corrected the S3 URL format in the log trace message in the `Load` function to include a slash between the bucket name and the path.