### PR TITLE
feat: dont return a error when the connection got reset

### DIFF
--- a/cloud/aws/sqs/sqs.go
+++ b/cloud/aws/sqs/sqs.go
@@ -116,9 +116,12 @@ func (c Client) Listen(queue string, waitTime int, msgs chan *sqs.Message) error
 				return err
 			}
 		}
-		log.Debugf("Received %d messages from SQS queue %v", len(output.Messages), queue)
-		for _, m := range output.Messages {
-			msgs <- m
+
+		if output != nil {
+			log.Debugf("Received %d messages from SQS queue %v", len(output.Messages), queue)
+			for _, m := range output.Messages {
+				msgs <- m
+			}
 		}
 	}
 }


### PR DESCRIPTION
This pull request introduces improvements to error handling and logging in the SQS and SFTP modules. Key changes include better handling of "connection reset by peer" errors, enhanced logging for debugging, and the addition of a custom error type for SFTP operations.

### SQS Module Changes:
* Added a log message to indicate when the `Listen` function starts listening for messages on an SQS queue. (`cloud/aws/sqs/sqs.go`, [cloud/aws/sqs/sqs.goR98-R99](diffhunk://#diff-cd71c84ac23fe0626ede009bfddf03b336acf99950b426a71f185fb4038a8ed0R98-R99))
* Improved error handling in the `Listen` function to retry on "connection reset by peer" errors and added debug logging for received messages. (`cloud/aws/sqs/sqs.go`, [cloud/aws/sqs/sqs.goR110-R119](diffhunk://#diff-cd71c84ac23fe0626ede009bfddf03b336acf99950b426a71f185fb4038a8ed0R110-R119))

### SFTP Module Changes:
* Introduced a new `resetError` type to handle "connection reset by peer" errors more explicitly. (`fileio/sftp-store.go`, [fileio/sftp-store.goR24-R36](diffhunk://#diff-4c9937e6b0c78da04b134033eca00d7437f1ba044f0ce0da60ddf0727e8228c9R24-R36))
* Updated the `connect` method to log and return a `resetError` when a "connection reset by peer" error occurs. (`fileio/sftp-store.go`, [fileio/sftp-store.goL48-R67](diffhunk://#diff-4c9937e6b0c78da04b134033eca00d7437f1ba044f0ce0da60ddf0727e8228c9L48-R67))
* Modified the `Save`, `Load`, `Delete`, and `List` methods to gracefully handle `resetError` by returning early without performing further operations. (`fileio/sftp-store.go`, [[1]](diffhunk://#diff-4c9937e6b0c78da04b134033eca00d7437f1ba044f0ce0da60ddf0727e8228c9L62-R90) [[2]](diffhunk://#diff-4c9937e6b0c78da04b134033eca00d7437f1ba044f0ce0da60ddf0727e8228c9L80-R113) [[3]](diffhunk://#diff-4c9937e6b0c78da04b134033eca00d7437f1ba044f0ce0da60ddf0727e8228c9L106-R158)